### PR TITLE
Display question tags on search and thread pages

### DIFF
--- a/client/components/Question.js
+++ b/client/components/Question.js
@@ -7,16 +7,20 @@ import "../static/styles/Question.css";
 
 export default class Question extends React.Component {
 	render() {
-		const {title, authorId, createdAt, body} = this.props.data;
+		const {title, authorId, tags, createdAt, body} = this.props.data;
+		const tagsList = tags.map(tag => tag.name).join(", ");
 
 		return (
 			<Card className="question_card">
 				<div className="question_card__meta">
 					<h4 className="question_card__meta__title">{title}</h4>
-					<span>posted {moment(createdAt).fromNow()} by {authorId.name}</span>
+					<span className="question_card__meta__creation">posted {moment(createdAt).fromNow()} by {authorId.name}</span>
 				</div>
 				<div className="question_card__body">
 					<span>{body}</span>
+				</div>
+				<div className="question_card__tags">
+					<span>Tags: {tagsList}</span>
 				</div>
 			</Card>
 		);

--- a/client/components/QuestionList.js
+++ b/client/components/QuestionList.js
@@ -16,18 +16,23 @@ class QuestionList extends React.Component {
 				itemLayout="horizontal"
 				locale={{emptyText: " "}}
 				dataSource={this.props.questions}
-				renderItem={item => (
-					<Link href={`/thread?id=${item._id}`}>
-						<a style={{textDecoration: "none"}}>
-							<List.Item actions={[<span>Author: {item.authorId.name}</span>]}> {/* eslint-disable-line react/jsx-key */}
-								<List.Item.Meta
-									title={<b>{item.title}</b>}
-									description={item.body}
-								/>
-							</List.Item>
-						</a>
-					</Link>
-				)}
+				renderItem={item => {
+					const {_id, authorId, tags, title, body} = item;
+					const tagsList = tags.map(tag => tag.name).join(", ");
+
+					return (
+						<Link href={`/thread?id=${_id}`}>
+							<a style={{textDecoration: "none"}}>
+								<List.Item actions={[<span>Author: {authorId.name}</span>, <span>Tags: {tagsList}</span>]}> {/* eslint-disable-line react/jsx-key */}
+									<List.Item.Meta
+										title={<b>{title}</b>}
+										description={body}
+									/>
+								</List.Item>
+							</a>
+						</Link>
+					);
+				}}
 			/>
 		);
 	}

--- a/client/components/Reply.js
+++ b/client/components/Reply.js
@@ -11,7 +11,7 @@ export default class Reply extends React.Component {
 
 		return (
 			<Card className="reply_card">
-				<div className="reply_card__title">
+				<div className="reply_card__creation">
 					<span>posted {moment(createdAt).fromNow()} by {authorId.name}</span>
 				</div>
 				<div className="reply_card__body">

--- a/client/static/styles/Question.css
+++ b/client/static/styles/Question.css
@@ -16,3 +16,11 @@
 .question_card__body {
 	padding-top: 10px;
 }
+
+.question_card__meta__creation, .question_card__tags {
+	color: rgb(180, 180, 180);
+}
+
+.question_card__tags {
+	padding-top: 20px;
+}

--- a/client/static/styles/Reply.css
+++ b/client/static/styles/Reply.css
@@ -6,3 +6,7 @@
 	border: 0px !important;
 	color: white !important;
 }
+
+.reply_card__creation {
+	color: rgb(220, 220, 220);
+}

--- a/server/components/search/search-controller.js
+++ b/server/components/search/search-controller.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 
+const Tag = require("../tags/tag-model");
 const {Question, Reply} = require("../content/content-model");
 const Thread = require("../thread/thread-model");
 const User = require("../users/user-model");
@@ -15,7 +16,10 @@ exports.getQuestion = async (req, res) => {
 	const queryString = query.split(" ").map(word => `"${word}"`).join(" ");// TODO: Escape the given input so that the user isn't able to run malicious queries on the database (such as `" (insert bad query here)`).
 
 	try {
-		const result = await Question.find({$text: {$search: queryString}}).populate("authorId", "-__v").select("-__v");
+		const result = await Question.find({$text: {$search: queryString}})
+			.populate("authorId", "-__v")
+			.populate("tags", "-__v")
+			.select("-__v");
 		res.status(200).json({result});
 	} catch (error) {
 		res.status(500).json(error);
@@ -24,47 +28,49 @@ exports.getQuestion = async (req, res) => {
 
 exports.prepopulate = async (req, res) => {
 	try {
-		/* 		Await User.deleteMany({});
-		await Question.deleteMany({});
-		await Reply.deleteMany({});
-		await Thread.deleteMany({}); */
 		const mockData = await User.findOne({name: "frank"});
-		if (!mockData) {
-			const frank = await User.create({name: "frank", email: "frank@test.com", firebaseId: "nsN9j7ln7rQk7VBTr0WRSe7vo8L2"});
-			const jhon = await User.create({name: "jhon", email: "jhon@test.com", firebaseId: "nsN9j7ln72bd7VBTr0WRSe7vo8L2"});
-
-			/* eslint-disable new-cap */
-			const questions = await Question.create([
-				{title: "This is the first title", body: "This is the first body", authorId: mongoose.Types.ObjectId(frank._id)},
-				{title: "This is the second title", body: "This is the second body", authorId: mongoose.Types.ObjectId(frank._id)},
-				{title: "This is the third title", body: "This is the third body", authorId: mongoose.Types.ObjectId(jhon._id)},
-				{title: "This is the fourth title", body: "This is the fourth body", authorId: mongoose.Types.ObjectId(frank._id)}
-			]);
-			const replies = await Reply.create([
-				{body: "This is the first reply to the first question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
-				{body: "This is the first reply to the second question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[1]._id)},
-				{body: "This is the first reply to the third question", authorId: mongoose.Types.ObjectId(frank._id), questionId: mongoose.Types.ObjectId(questions[2]._id)},
-				{body: "This is the second reply to the first question", authorId: mongoose.Types.ObjectId(frank._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
-				{body: "This is the third reply to the first question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
-				{body: "This is the second reply to the third question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[2]._id)}
-			]);
-			/* eslint-enable new-cap */
-
-			const threads = [];
-			questions.forEach(question => {
-				const thread = {
-					question: question._id,
-					replies: replies.filter(reply => reply.questionId === question._id).map(el => el._id)};
-				threads.push(thread);
-			});
-
-			await Thread.create(threads);
-			console.log("questions", questions);
-
-			return res.status(200).json({message: "Db Populated"});
+		if (mockData) {
+			return res.status(200).json({message: "Db was already filled with mock data"});
 		}
 
-		return res.status(200).json({message: "Db was already filled with mock data"});
+		const frank = await User.create({name: "frank", email: "frank@test.com", firebaseId: "nsN9j7ln7rQk7VBTr0WRSe7vo8L2"});
+		const jhon = await User.create({name: "jhon", email: "jhon@test.com", firebaseId: "nsN9j7ln72bd7VBTr0WRSe7vo8L2"});
+
+		/* eslint-disable new-cap */
+		const tags = await Tag.create([
+			{name: "tag1"},
+			{name: "tag2"},
+			{name: "tag3"},
+			{name: "tag4"},
+			{name: "tag5"}
+		]);
+		const questions = await Question.create([
+			{title: "This is the first title", body: "This is the first body", authorId: mongoose.Types.ObjectId(frank._id), tags: [mongoose.Types.ObjectId(tags[0]._id), mongoose.Types.ObjectId(tags[1]._id)]},
+			{title: "This is the second title", body: "This is the second body", authorId: mongoose.Types.ObjectId(frank._id), tags: [mongoose.Types.ObjectId(tags[1]._id), mongoose.Types.ObjectId(tags[2]._id)]},
+			{title: "This is the third title", body: "This is the third body", authorId: mongoose.Types.ObjectId(jhon._id)},
+			{title: "This is the fourth title", body: "This is the fourth body", authorId: mongoose.Types.ObjectId(frank._id)}
+		]);
+		const replies = await Reply.create([
+			{body: "This is the first reply to the first question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
+			{body: "This is the first reply to the second question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[1]._id)},
+			{body: "This is the first reply to the third question", authorId: mongoose.Types.ObjectId(frank._id), questionId: mongoose.Types.ObjectId(questions[2]._id)},
+			{body: "This is the second reply to the first question", authorId: mongoose.Types.ObjectId(frank._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
+			{body: "This is the third reply to the first question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[0]._id)},
+			{body: "This is the second reply to the third question", authorId: mongoose.Types.ObjectId(jhon._id), questionId: mongoose.Types.ObjectId(questions[2]._id)}
+		]);
+		/* eslint-enable new-cap */
+
+		const threads = [];
+		for (const question of questions) {
+			threads.push({
+				question: question._id,
+				replies: replies.filter(reply => reply.questionId === question._id).map(el => el._id)
+			});
+		}
+
+		await Thread.create(threads);
+
+		return res.status(200).json({message: "Db Populated"});
 	} catch (error) {
 		console.log(error);
 		res.status(500).json(error);

--- a/server/components/tags/tag-model.js
+++ b/server/components/tags/tag-model.js
@@ -4,9 +4,6 @@ const tagSchema = new mongoose.Schema({
 	name: {
 		type: String,
 		required: true
-	},
-	children: {
-		type: [String]
 	}
 });
 

--- a/server/components/thread/thread-controller.js
+++ b/server/components/thread/thread-controller.js
@@ -2,11 +2,32 @@ const Thread = require("./thread-model");
 
 exports.getThread = async (req, res) => {
 	const {questionId} = req.params;
+
 	try {
 		const thread = await Thread // TODO: Remvoe the `type` field from objects returned here, and rename the `authorId` field to `author`.
 			.findOne({question: questionId})
-			.populate({path: "question", select: "-__v", populate: {path: "authorId", select: "-__v -firebaseId"}})
-			.populate({path: "replies", select: "-__v", populate: {path: "authorId", select: "-__v -firebaseId"}})
+			.populate({
+				path: "question",
+				select: "-__v",
+				populate: [
+					{
+						path: "authorId",
+						select: "-__v -firebaseId"
+					},
+					{
+						path: "tags",
+						select: "-__v"
+					}
+				]
+			})
+			.populate({
+				path: "replies",
+				select: "-__v",
+				populate: {
+					path: "authorId",
+					select: "-__v -firebaseId"
+				}
+			})
 			.select("-__v");
 
 		res.status(200).json({thread});


### PR DESCRIPTION
This enables users to see a question's tags by mentioning them in the search page (in case the question has been returned as a search result) and in the thread page (in case the user has navigated to the question's thread).