### PR TITLE
Update tag questions when navigating to other tags

### DIFF
--- a/client/components/QuestionForm.js
+++ b/client/components/QuestionForm.js
@@ -5,6 +5,7 @@ import {Form, Input, Button} from "antd";
 
 import SearchTag from "./SearchTag";
 
+import "antd/dist/antd.css";
 import "../static/styles/QuestionForm.css";
 
 const {Item: FormItem} = Form;

--- a/client/components/TagList.js
+++ b/client/components/TagList.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import Link from "next/link";
 import {Tag} from "antd";
 
+import "antd/dist/antd.css";
 import "../static/styles/TagList.css";
 
 class TagList extends React.Component {

--- a/client/pages/tag.js
+++ b/client/pages/tag.js
@@ -12,10 +12,16 @@ class Tag extends React.Component {
 	};
 
 	static getInitialProps({query}) {
-		return {tagName: query.name};
+		return {
+			tagName: encodeURIComponent(query.name.toLowerCase())
+		};
 	}
 
 	componentDidMount() {
+		this.fetchTagData();
+	}
+
+	componentDidUpdate() {
 		this.fetchTagData();
 	}
 

--- a/server/components/tags/tag-controllers.js
+++ b/server/components/tags/tag-controllers.js
@@ -6,7 +6,7 @@ exports.getTags = async (req, res) => {
 	const findOptions = query ? [{
 		name: {
 			$regex: query,
-			$options: "ig"
+			$options: "i"
 		}
 	}] : [];
 
@@ -24,7 +24,10 @@ exports.getTags = async (req, res) => {
 
 exports.getTagQuestions = async (req, res) => {
 	const {tagName} = req.params;
-	const tagId = await Tag.findOne({name: tagName}).select("_id");
+	const tagId = await Tag.findOne({name: {
+		$regex: tagName,
+		$options: "i"
+	}}).select("_id");
 
 	try {
 		const questions = await Question


### PR DESCRIPTION
This fixes a bug where when navigating from one tag page to another the questions aren't updated. This also makes the `/tag/browse/{tagName}` route case-insensitive.